### PR TITLE
Make userId for identify without null safety (Without Null Safety)

### DIFF
--- a/lib/src/segment.dart
+++ b/lib/src/segment.dart
@@ -10,7 +10,7 @@ class Segment {
   static SegmentPlatform get _segment => SegmentPlatform.instance;
 
   static Future<void> identify({
-    @required userId,
+    String userId,
     Map<String, dynamic> traits,
     Map<String, dynamic> options,
   }) {

--- a/lib/src/segment_method_channel.dart
+++ b/lib/src/segment_method_channel.dart
@@ -7,7 +7,7 @@ const MethodChannel _channel = MethodChannel('flutter_segment');
 
 class SegmentMethodChannel extends SegmentPlatform {
   Future<void> identify({
-    @required userId,
+    String userId,
     Map<String, dynamic> traits,
     Map<String, dynamic> options,
   }) async {

--- a/lib/src/segment_platform_interface.dart
+++ b/lib/src/segment_platform_interface.dart
@@ -12,7 +12,7 @@ abstract class SegmentPlatform {
   static SegmentPlatform instance = SegmentMethodChannel();
 
   Future<void> identify({
-    @required userId,
+    String userId,
     Map<String, dynamic> traits,
     Map<String, dynamic> options,
   }) {


### PR DESCRIPTION
This is a compatibility PR created to be able to use https://github.com/claimsforce-gmbh/flutter-segment/pull/59 without Null Safety if your project is not migrated.

The source commit was https://github.com/la-haus/flutter-library-segment/commit/7afec152108ea192d58aaed10d662f9528e11a79 (before Null Safety)

To use this include the dependency in `pubspec.yaml` like this:
```
flutter_segment:
    git:
      url: https://github.com/la-haus/flutter-segment.git
      ref: feature/allow-no-userId-for-identify-without-null-safety
```