### PR TITLE
feat(Flush): add new flush method for Android/iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,20 @@ To use this plugin, add `flutter_segment` as a [dependency in your pubspec.yaml 
 Since version `3.5.0` we are forcing all users to use `use_frameworks!` within the [`Podfile`](https://github.com/claimsforce-gmbh/flutter-segment/blob/master/example/ios/Podfile#L31) due to import issues of some 3rd party dependencies.
 
 ### Supported methods
-| Method | Android | iOS | Web |
-|---|---|---|---|
-| `identify` | X | X | X |
-| `track` | X | X | X |
-| `screen` | X | X | X |
-| `group` | X | X | X |
-| `alias` | X | X | X |
+| Method           | Android | iOS | Web |
+|------------------|---|---|---|
+| `identify`       | X | X | X |
+| `track`          | X | X | X |
+| `screen`         | X | X | X |
+| `group`          | X | X | X |
+| `alias`          | X | X | X |
 | `getAnonymousId` | X | X | X |
-| `reset` | X | X | X |
-| `disable` | X | X | |
-| `enable` | X | X | |
-| `debug` | X* | X | X |
-| `setContext` | X | X | |
+| `reset`          | X | X | X |
+| `disable`        | X | X | |
+| `enable`         | X | X | |
+| `flush`          | X | X | |
+| `debug`          | X* | X | X |
+| `setContext`     | X | X | |
 
 \* Debugging must be set as a configuration parameter in `AndroidManifest.xml` (see below). The official segment library does not offer the debug method for Android.
 

--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -160,6 +160,8 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
       this.disable(call, result);
     } else if (call.method.equals("enable")) {
       this.enable(call, result);
+    } else if (call.method.equals("flush")) {
+      this.flush(call, result);
     } else {
       result.notImplemented();
     }
@@ -324,6 +326,15 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
   private void enable(MethodCall call, Result result) {
     try {
       Analytics.with(this.applicationContext).optOut(false);
+      result.success(true);
+    } catch (Exception e) {
+      result.error("FlutterSegmentException", e.getLocalizedMessage(), null);
+    }
+  }
+
+  private void flush(MethodCall call, Result result) {
+    try {
+      Analytics.with(this.applicationContext).flush();
       result.success(true);
     } catch (Exception e) {
       result.error("FlutterSegmentException", e.getLocalizedMessage(), null);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,6 +43,10 @@ class MyApp extends StatelessWidget {
     Segment.screen(
       screenName: 'Example Screen',
     );
+
+    // If you want to flush the data now
+    Segment.flush();
+
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -138,6 +138,8 @@ static BOOL wasSetupFromFile = NO;
     [self disable:result];
   } else if ([@"enable" isEqualToString:call.method]) {
     [self enable:result];
+  } else if ([@"flush" isEqualToString:call.method]) {
+    [self flush:call result:result];
   } else if ([@"debug" isEqualToString:call.method]) {
     [self debug:call result:result];
   } else if ([@"setContext" isEqualToString:call.method]) {
@@ -305,6 +307,18 @@ static BOOL wasSetupFromFile = NO;
 - (void)enable:(FlutterResult)result {
   @try {
     [[SEGAnalytics sharedAnalytics] enable];
+    result([NSNumber numberWithBool:YES]);
+  }
+  @catch (NSException *exception) {
+    result([FlutterError errorWithCode:@"FlutterSegmentException"
+      message:[exception reason]
+      details: [NSThread  callStackSymbols].description]);
+  }
+}
+
+- (void)flush:(FlutterResult)result {
+  @try {
+    [[SEGAnalytics sharedAnalytics] flush];
     result([NSNumber numberWithBool:YES]);
   }
   @catch (NSException *exception) {

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -139,7 +139,7 @@ static BOOL wasSetupFromFile = NO;
   } else if ([@"enable" isEqualToString:call.method]) {
     [self enable:result];
   } else if ([@"flush" isEqualToString:call.method]) {
-    [self flush:call result:result];
+    [self flush:result];
   } else if ([@"debug" isEqualToString:call.method]) {
     [self debug:call result:result];
   } else if ([@"setContext" isEqualToString:call.method]) {

--- a/lib/src/segment.dart
+++ b/lib/src/segment.dart
@@ -93,6 +93,10 @@ class Segment {
     return _segment.enable();
   }
 
+  static Future<void> flush() {
+    return _segment.flush();
+  }
+
   static Future<void> debug(bool enabled) {
     if (Platform.isAndroid) {
       throw Exception(

--- a/lib/src/segment_method_channel.dart
+++ b/lib/src/segment_method_channel.dart
@@ -136,6 +136,15 @@ class SegmentMethodChannel extends SegmentPlatform {
   }
 
   @override
+  Future<void> flush() async {
+    try {
+      await _channel.invokeMethod('flush');
+    } on PlatformException catch (exception) {
+      print(exception);
+    }
+  }
+
+  @override
   Future<void> debug(bool enabled) async {
     try {
       await _channel.invokeMethod('debug', {

--- a/lib/src/segment_platform_interface.dart
+++ b/lib/src/segment_platform_interface.dart
@@ -72,6 +72,10 @@ abstract class SegmentPlatform {
     throw UnimplementedError('enable() has not been implemented.');
   }
 
+  Future<void> flush() {
+    throw UnimplementedError('flush() has not been implemented.');
+  }
+
   Future<void> debug(bool enabled) {
     throw UnimplementedError('debug() has not been implemented.');
   }


### PR DESCRIPTION
If you are in debug mode, been able to flush events, It's pretty helpful.

Currently, this is not allowed

# Docs
- iOS: https://segment.com/docs/connections/sources/catalog/libraries/mobile/ios/#flushing
- Android: https://segment.com/docs/connections/sources/catalog/libraries/mobile/kotlin-android/#flush