### PR TITLE
docs(Readme): update package owners information on pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: flutter_segment
 description: Flutter implementation of Segment Analytics for iOS, Android and Web
 version: 3.5.0
-homepage: https://www.claimsforce.com
-repository: https://github.com/claimsforce-gmbh/flutter-segment
-issue_tracker: https://github.com/claimsforce-gmbh/flutter-segment/issues
-documentation: https://github.com/claimsforce-gmbh/flutter-segment#readme
+homepage: https://lahaus.com
+repository: https://github.com/la-haus/flutter-library-segment
+issue_tracker: https://github.com/la-haus/flutter-library-segment/issues
+documentation: https://github.com/la-haus/flutter-library-segment#readme
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Current information points to the old [claimsforce-gmbh/flutter-segment](https://github.com/claimsforce-gmbh/flutter-segment) repository, and it is no longer maintained there by our friends, again, thanks for the effort doing it :)