### PR TITLE
[iOS] Fix userId nil

### DIFF
--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -187,6 +187,8 @@ static BOOL wasSetupFromFile = NO;
     NSDictionary *traits = call.arguments[@"traits"];
     NSDictionary *options = call.arguments[@"options"];
 
+    userId = [userId isEqual:[NSNull null]]? nil: userId;
+
     [[SEGAnalytics sharedAnalytics] identify: userId
                       traits: traits
                      options: options];


### PR DESCRIPTION
Fixes a bug on iOS, where Segment would not report correctly when calling `identify` with `userId: null`.

Explanation: in iOS when `userId` is obtained from arguments it might be `NSNull`, but the Segment library expects it to be `nil`. Added a line to convert `userId` from `NSNull` to `nil`.

Related issue [Identify userId is optional but the implementation does not reflect this](https://github.com/segmentio/analytics-ios/issues/1024).