### PR TITLE
[Android] Update Segment and Amplitude integration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,8 @@ android {
     }
 
     dependencies {
-        implementation 'com.segment.analytics.android:analytics:4.10.0'
-        implementation 'com.segment.analytics.android.integrations:amplitude:3.0.3'
+        implementation 'com.segment.analytics.android:analytics:4.10.4'
+        implementation 'com.segment.analytics.android.integrations:amplitude:3.1.0'
         implementation 'com.appsflyer:segment-android-integration:6.5.2'
     }
 }


### PR DESCRIPTION
Updates for Android Segment dependencies to address Google Play policies violation and keep the project up to date.

Both updated dependencies had no breaking changes inside, so nothing breaking is expected from this update:
https://github.com/segmentio/analytics-android/blob/master/CHANGELOG.md
https://github.com/segment-integrations/analytics-android-integration-amplitude/blob/master/CHANGELOG.md

Suggest to merge this PR after #29 , because to test this branch a person would need to do adjustments already done in mentioned PR, like change in AndroidManifest of `android:name` to not use embedding V1.

Closes #30