### PR TITLE
Read the Write Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,10 @@ void main() {
   /// `setContext` during the app initialization.
   WidgetsFlutterBinding.ensureInitialized();
   
-  String writeKey;
-  if(Platform.isAndroid){
-    writeKey = "ANDROID_WRITE_KEY";
-  } else{ //iOS
-      writeKey = "IOS_WRITE_KEY";
-  }
-
   Segment.config(
     options: SegmentConfig(
-      writeKey: 'YOUR_WRITE_KEY_GOES_HERE',
+      androidWriteKey: 'YOUR_ANDROID_WRITE_KEY_GOES_HERE',
+      iosWriteKey: 'YOUR_IOS_WRITE_KEY_GOES_HERE',
       trackApplicationLifecycleEvents: false,
       amplitudeIntegrationEnabled: false,
       debug: false,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,8 @@ void main() {
 
   Segment.config(
     options: SegmentConfig(
-      writeKey: 'YOUR_WRITE_KEY_GOES_HERE',
+      androidWriteKey: 'YOUR_ANDROID_WRITE_KEY_GOES_HERE',
+      iosWriteKey: 'YOUR_IOS_WRITE_KEY_GOES_HERE',
       trackApplicationLifecycleEvents: false,
     ),
   );

--- a/lib/src/segment_config.dart
+++ b/lib/src/segment_config.dart
@@ -1,17 +1,38 @@
+
+import 'dart:io';
+
 class SegmentConfig {
+  
   SegmentConfig({
-    required this.writeKey,
+    this.androidWriteKey,
+    this.iosWriteKey,
     this.trackApplicationLifecycleEvents = false,
     this.amplitudeIntegrationEnabled = false,
     this.appsflyerIntegrationEnabled = false,
     this.debug = false,
-  });
+  }) {
+    if (Platform.isIOS) {
+      assert(iosWriteKey != null, 'Provide an right Write Key to IOS platform');
+    } else if (Platform.isAndroid) {
+      assert(androidWriteKey != null, 'Provide an right Write Key to Android platform');
+    }
+  }
 
-  final String writeKey;
   final bool trackApplicationLifecycleEvents;
+
   final bool amplitudeIntegrationEnabled;
+
   final bool appsflyerIntegrationEnabled;
+
   final bool debug;
+
+  final String? androidWriteKey;
+
+  final String? iosWriteKey;
+
+  String get writeKey {
+    return Platform.isIOS ? iosWriteKey! : androidWriteKey!;
+  }
 
   Map<String, dynamic> toMap() {
     return {


### PR DESCRIPTION
The most applications to Flutter have support for IOS and Android therefore it does make sense to keep the loading WRITE_KEY within the package.