### PR TITLE
Facebook App Events Integration

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,14 +1,34 @@
 PODS:
   - Amplitude (8.5.0)
   - Analytics (4.1.6)
+  - AppsFlyerFramework (6.5.4):
+    - AppsFlyerFramework/Main (= 6.5.4)
+  - AppsFlyerFramework/Main (6.5.4)
+  - FBAEMKit (12.3.2):
+    - FBSDKCoreKit_Basics (= 12.3.2)
+  - FBSDKCoreKit (12.3.2):
+    - FBAEMKit (= 12.3.2)
+    - FBSDKCoreKit_Basics (= 12.3.2)
+  - FBSDKCoreKit_Basics (12.3.2)
   - Flutter (1.0.0)
   - flutter_segment (0.0.1):
     - Analytics (= 4.1.6)
     - Flutter
     - Segment-Amplitude (= 3.3.2)
+    - segment-appsflyer-ios (= 6.5.2)
+    - Segment-Facebook-App-Events (= 2.1.3)
   - Segment-Amplitude (3.3.2):
     - Amplitude (~> 8.3)
     - Analytics
+  - segment-appsflyer-ios (6.5.2):
+    - Analytics
+    - segment-appsflyer-ios/Main (= 6.5.2)
+  - segment-appsflyer-ios/Main (6.5.2):
+    - Analytics
+    - AppsFlyerFramework (~> 6.5.2)
+  - Segment-Facebook-App-Events (2.1.3):
+    - Analytics
+    - FBSDKCoreKit (~> 12.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -18,7 +38,13 @@ SPEC REPOS:
   trunk:
     - Amplitude
     - Analytics
+    - AppsFlyerFramework
+    - FBAEMKit
+    - FBSDKCoreKit
+    - FBSDKCoreKit_Basics
     - Segment-Amplitude
+    - segment-appsflyer-ios
+    - Segment-Facebook-App-Events
 
 EXTERNAL SOURCES:
   Flutter:
@@ -29,10 +55,16 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Amplitude: ef9ed339ddd33c9183edf63fa4bbaa86cf873321
   Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
+  AppsFlyerFramework: e309a6cab366296bf891dc68b175de1e9a44f86c
+  FBAEMKit: 955ca52eba8219c20f90774e8c6ff8bc7b3192a3
+  FBSDKCoreKit: 678f64eda3f0ff25c189c2ebbfe87b1d96a85a6d
+  FBSDKCoreKit_Basics: 6bee7c1f0932432901781203fa5e587ec5099148
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_segment: 9cdace39639298eb31ad1555e5916edf8f9fc6b8
+  flutter_segment: 98d641efb33f3e5a09038ecfa99d805dc927cbd4
   Segment-Amplitude: 6c1e59c8c278a21029ba7a6a788fcb31b9233a2c
+  segment-appsflyer-ios: 78c65acfd78dd17ed347623f01919c44b0226174
+  Segment-Facebook-App-Events: 7ddd4516db030548f93b93ecb1904788e074371c
 
 PODFILE CHECKSUM: c5a3a731b49f8e74894a9db5e2e52860ff4a4538
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -167,7 +167,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -232,11 +232,19 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Amplitude/Amplitude.framework",
 				"${BUILT_PRODUCTS_DIR}/Analytics/Segment.framework",
+				"${BUILT_PRODUCTS_DIR}/Segment-Facebook-App-Events/Segment_Facebook_App_Events.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBAEMKit/FBAEMKit.framework/FBAEMKit",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework/FBSDKCoreKit",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/FBSDKCoreKit_Basics/FBSDKCoreKit_Basics.framework/FBSDKCoreKit_Basics",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Amplitude.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Segment_Facebook_App_Events.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBAEMKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit_Basics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -377,7 +385,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -506,7 +517,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
@@ -531,7 +545,10 @@
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.7.0"
+    version: "3.11.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -85,7 +85,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   matcher:
     dependency: transitive
     description:
@@ -93,13 +93,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -113,7 +106,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -125,7 +118,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -160,14 +153,21 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.3"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.4"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.11.2"
+    version: "3.11.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -4,6 +4,7 @@
 #import <Segment/SEGContext.h>
 #import <Segment/SEGMiddleware.h>
 #import <Segment_Amplitude/SEGAmplitudeIntegrationFactory.h>
+#import <Segment_Facebook_App_Events/SEGFacebookAppEventsIntegrationFactory.h>
 
 @implementation FlutterSegmentPlugin
 // Contents to be appended to the context
@@ -350,6 +351,7 @@ static BOOL wasSetupFromFile = NO;
     NSString *writeKey = [dict objectForKey: @"com.claimsforce.segment.WRITE_KEY"];
     BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS"] boolValue];
     BOOL isAmplitudeIntegrationEnabled = [[dict objectForKey: @"com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION"] boolValue];
+    BOOL isFacebookAppEventsIntegrationEnabled = [[dict objectForKey: @"com.claimsforce.segment.ENABLE_FACEBOOK_INTEGRATION"] boolValue];
     if(!writeKey) {
         return nil;
     }
@@ -360,6 +362,10 @@ static BOOL wasSetupFromFile = NO;
       [configuration use:[SEGAmplitudeIntegrationFactory instance]];
     }
 
+    if (isFacebookAppEventsIntegrationEnabled) {
+      [configuration use:[SEGFacebookAppEventsIntegrationFactory instance]];
+    }
+
     return configuration;
 }
 
@@ -368,6 +374,7 @@ static BOOL wasSetupFromFile = NO;
     BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"trackApplicationLifecycleEvents"] boolValue];
     BOOL isAmplitudeIntegrationEnabled = [[dict objectForKey: @"amplitudeIntegrationEnabled"] boolValue];
     BOOL isAppsflyerIntegrationEnabled = [[dict objectForKey: @"appsflyerIntegrationEnabled"] boolValue];
+    BOOL isFacebookAppEventsIntegrationEnabled = [[dict objectForKey: @"facebookAppEventsIntegrationEnabled"] boolValue];
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
     configuration.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
 
@@ -377,6 +384,10 @@ static BOOL wasSetupFromFile = NO;
 
     if (isAppsflyerIntegrationEnabled) {
       [configuration use:[SEGAppsFlyerIntegrationFactory instance]];
+    }
+
+    if (isFacebookAppEventsIntegrationEnabled) {
+      [configuration use:[SEGFacebookAppEventsIntegrationFactory instance]];
     }
 
     return configuration;

--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -18,6 +18,7 @@ A new flutter plugin project.
   s.dependency 'Analytics', '4.1.6'
   s.dependency 'Segment-Amplitude', '3.3.2'
   s.dependency 'segment-appsflyer-ios', '6.5.2'
+  s.dependency 'Segment-Facebook-App-Events', '2.1.3'
   s.ios.deployment_target = '11.0'
 
   # Added because Segment-Amplitude dependencies on iOS cause this error:

--- a/lib/src/segment_config.dart
+++ b/lib/src/segment_config.dart
@@ -4,6 +4,7 @@ class SegmentConfig {
     this.trackApplicationLifecycleEvents = false,
     this.amplitudeIntegrationEnabled = false,
     this.appsflyerIntegrationEnabled = false,
+    this.facebookAppEventsIntegrationEnabled = false,
     this.debug = false,
   });
 
@@ -11,6 +12,7 @@ class SegmentConfig {
   final bool trackApplicationLifecycleEvents;
   final bool amplitudeIntegrationEnabled;
   final bool appsflyerIntegrationEnabled;
+  final bool facebookAppEventsIntegrationEnabled;
   final bool debug;
 
   Map<String, dynamic> toMap() {
@@ -19,6 +21,8 @@ class SegmentConfig {
       'trackApplicationLifecycleEvents': trackApplicationLifecycleEvents,
       'amplitudeIntegrationEnabled': amplitudeIntegrationEnabled,
       'appsflyerIntegrationEnabled': appsflyerIntegrationEnabled,
+      'facebookAppEventsIntegrationEnabled':
+          facebookAppEventsIntegrationEnabled,
       'debug': debug,
     };
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flutter_segment
 description: Flutter implementation of Segment Analytics for iOS, Android and Web
-version: 3.11.0
+version: 3.11.1
 homepage: https://lahaus.com
 repository: https://github.com/la-haus/flutter-library-segment
 issue_tracker: https://github.com/la-haus/flutter-library-segment/issues
 documentation: https://github.com/la-haus/flutter-library-segment#readme
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.4"
 
 dependencies:


### PR DESCRIPTION
This PR adds [Facebook App Events](https://segment.com/docs/connections/destinations/catalog/facebook-app-events/) in a similar manner to Amplitude:
 You can now set a boolean to enable:
 ```dart
  Segment.config(
      options: SegmentConfig(
        writeKey: _writeKey,
        trackApplicationLifecycleEvents: true,
        facebookAppEventsIntegrationEnabled: true,
        debug: kDebugMode,
      ),
    );
 ```
 
 You will need to add in this code too, to get Facebook to work, IDFA can be obtained via different package:
 ```dart
Segment.setContext({
      'device': {
        'adTrackingEnabled': adTrackingEnabled.toString(),
        'advertisingId': advertisingId,
      }
    });
 ```