### PR TITLE
Update iOS podspec dependency and metadata

### DIFF
--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_segment'
-  s.version          = '3.1.1'
+  s.version          = '3.11.0'
   s.summary          = 'Segment.io plugin for Flutter'
   s.description      = <<-DESC
 Library to let Flutter apps use Segment.io

--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -3,21 +3,23 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_segment'
-  s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.version          = '3.1.1'
+  s.summary          = 'Segment.io plugin for Flutter'
   s.description      = <<-DESC
-A new flutter plugin project.
+Library to let Flutter apps use Segment.io
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/la-haus/flutter-segment'
+  s.license          = { :type => 'MIT', :file => '../LICENSE' }
+  s.author           = 'La Haus'
+  s.source           = { :git => "https://github.com/la-haus/flutter-segment.git", :tag => s.version.to_s }
+  
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
+  
   s.dependency 'Flutter'
-  s.dependency 'Analytics', '4.1.6'
-  s.dependency 'Segment-Amplitude', '3.3.2'
-  s.dependency 'segment-appsflyer-ios', '6.5.2'
+  s.dependency 'Analytics', '~> 4.1.6'
+  s.dependency 'Segment-Amplitude', '~> 3.3.2'
+  s.dependency 'segment-appsflyer-ios', '~> 6.8.0'
   s.ios.deployment_target = '11.0'
 
   # Added because Segment-Amplitude dependencies on iOS cause this error:

--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -17,9 +17,9 @@ Library to let Flutter apps use Segment.io
   s.public_header_files = 'Classes/**/*.h'
   
   s.dependency 'Flutter'
-  s.dependency 'Analytics', '~> 4.1.6'
-  s.dependency 'Segment-Amplitude', '~> 3.3.2'
-  s.dependency 'segment-appsflyer-ios', '~> 6.8.0'
+  s.dependency 'Analytics', '4.1.6'
+  s.dependency 'Segment-Amplitude', '3.3.2'
+  s.dependency 'segment-appsflyer-ios', '6.8.0'
   s.ios.deployment_target = '11.0'
 
   # Added because Segment-Amplitude dependencies on iOS cause this error:


### PR DESCRIPTION
This PR updates AppsFlyer dependency for iOS pod part as after recent bump of AppsFlyer to 6.8.0 it is now impossible to use Segment 3.11.0  with AppsFlyer unless the project isn't locked on AppsFlyer 6.5.2 version:

<img width="946" alt="Screenshot 2022-08-15 at 13 05 59" src="https://user-images.githubusercontent.com/13467769/184623210-dc70c5c6-6034-4cf2-9fac-0d1e506f3656.png">

Additionally saw that error description provides wrong info about `flutter_segment` version by showing version `0.0.1`. Thus, updated pod spec data to match https://guides.cocoapods.org/syntax/podspec.html#specification and provide correct info in cases like I had.