### PR TITLE
Fix for iOS Application Installed event

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -39,10 +39,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>com.claimsforce.segment.WRITE_KEY</key>
-	<string>YOUR_WRITE_KEY_GOES_HERE</string>
-	<key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
-	<false/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,12 +3,12 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_segment/flutter_segment.dart';
 
-void main() {
+void main() async {
   /// Wait until the platform channel is properly initialized so we can call
   /// `setContext` during the app initialization.
   WidgetsFlutterBinding.ensureInitialized();
 
-  Segment.config(
+  await Segment.config(
     options: SegmentConfig(
       writeKey: 'YOUR_WRITE_KEY_GOES_HERE',
       trackApplicationLifecycleEvents: false,

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -437,12 +437,12 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         }];
     }
 
-    [self track:@"Application Opened" properties:@{
+    [[SEGAnalytics sharedAnalytics] track:@"Application Opened" properties:@{
         @"from_background" : @NO,
         @"version" : currentVersion ?: @"",
         @"build" : currentBuild ?: @"",
-        @"referring_application" : launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
-        @"url" : launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
+        @"referring_application" : @"",
+        @"url" : @"",
     }];
 
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -155,6 +155,9 @@ static BOOL wasSetupFromFile = NO;
     NSDictionary *options = call.arguments[@"options"];
     SEGAnalyticsConfiguration *configuration = [FlutterSegmentPlugin createConfigFromDict:options];
     [self setup:configuration];
+    if(!wasSetupFromFile) {
+        [self trackInstalledEvent];
+    }
     result([NSNumber numberWithBool:YES]);
   }
   @catch (NSException *exception) {
@@ -394,6 +397,49 @@ static BOOL wasSetupFromFile = NO;
     }
   }];
   return result;
+}
+
+
+#pragma mark Work around for Firing Installed / Updated events
+// See https://github.com/segmentio/analytics-ios/blob/fc64997865619f73bbab196c164f7845a13da110/Segment/Classes/SEGAnalytics.m#L163
+
+NSString *const SEGVersionKey = @"SEGVersionKey";
+NSString *const SEGBuildKeyV1 = @"SEGBuildKey";
+NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
+
+- (void)trackInstalledEvent
+{
+    // Previously SEGBuildKey was stored an integer. This was incorrect because the CFBundleVersion
+    // can be a string. This migrates SEGBuildKey to be stored as a string.
+    NSInteger previousBuildV1 = [[NSUserDefaults standardUserDefaults] integerForKey:SEGBuildKeyV1];
+    if (previousBuildV1) {
+        [[NSUserDefaults standardUserDefaults] setObject:[@(previousBuildV1) stringValue] forKey:SEGBuildKeyV2];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:SEGBuildKeyV1];
+    }
+
+    NSString *previousVersion = [[NSUserDefaults standardUserDefaults] stringForKey:SEGVersionKey];
+    NSString *previousBuildV2 = [[NSUserDefaults standardUserDefaults] stringForKey:SEGBuildKeyV2];
+
+    NSString *currentVersion = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
+    NSString *currentBuild = [[NSBundle mainBundle] infoDictionary][@"CFBundleVersion"];
+
+    if (!previousBuildV2) {
+        [[SEGAnalytics sharedAnalytics] track:@"Application Installed" properties:@{
+            @"version" : currentVersion ?: @"",
+            @"build" : currentBuild ?: @"",
+        }];
+    } else if (![currentBuild isEqualToString:previousBuildV2]) {
+        [[SEGAnalytics sharedAnalytics] track:@"Application Updated" properties:@{
+            @"previous_version" : previousVersion ?: @"",
+            @"previous_build" : previousBuildV2 ?: @"",
+            @"version" : currentVersion ?: @"",
+            @"build" : currentBuild ?: @"",
+        }];
+    }
+
+    [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
+    [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SEGBuildKeyV2];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 @end

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -437,6 +437,14 @@ NSString *const SEGBuildKeyV2 = @"SEGBuildKeyV2";
         }];
     }
 
+    [self track:@"Application Opened" properties:@{
+        @"from_background" : @NO,
+        @"version" : currentVersion ?: @"",
+        @"build" : currentBuild ?: @"",
+        @"referring_application" : launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] ?: @"",
+        @"url" : launchOptions[UIApplicationLaunchOptionsURLKey] ?: @"",
+    }];
+
     [[NSUserDefaults standardUserDefaults] setObject:currentVersion forKey:SEGVersionKey];
     [[NSUserDefaults standardUserDefaults] setObject:currentBuild forKey:SEGBuildKeyV2];
     [[NSUserDefaults standardUserDefaults] synchronize];


### PR DESCRIPTION
### Context
This PR is a workaround fix for the `Application Installed` events not firing when setting the config via dart and not via a file (`info.plist`), issue #26.

### Fix Details:
Due to the method sequence and the way the native library works, [described here](https://github.com/la-haus/flutter-segment/issues/26#issuecomment-1215282446), we need to either call the dart code `Segment.config()` in `didFinishLaunchingWithOptions()`, similar to how the configFromFile works **or** send the `Application Installed` event when we call the dart code `Segment.config()`. 

As I dont think there is an easy way to call `Segment.config()` in the native code `didFinishLaunchingWithOptions()`, I have instead opted to add a similar method to the way the native code works when sending `Application Installed` / `Application Updated` events, this code is [here](https://github.com/segmentio/analytics-ios/blob/fc64997865619f73bbab196c164f7845a13da110/Segment/Classes/SEGAnalytics.m#L163).

This will make use of the same `NSUserDefaults` keys as the native library and manually send the events.

This maybe isn't the best way to explain this fix so happy to chat. Also keep up the good work 💙.