### PR TITLE
Update Appsflyer SDK iOS dependency

### DIFF
--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -19,7 +19,7 @@ Library to let Flutter apps use Segment.io
   s.dependency 'Flutter'
   s.dependency 'Analytics', '4.1.6'
   s.dependency 'Segment-Amplitude', '3.3.2'
-  s.dependency 'segment-appsflyer-ios', '6.9.1'
+  s.dependency 'segment-appsflyer-ios', '6.10.1'
   s.ios.deployment_target = '11.0'
 
   # Added because Segment-Amplitude dependencies on iOS cause this error:


### PR DESCRIPTION
Updating Appsflyer iOS SDK version, to get it in sync with appsflyer's own flutter package dependencies - otherwise both packages cannot be used at the same time

https://pub.dev/packages/appsflyer_sdk/changelog

<img width="397" alt="image" src="https://github.com/la-haus/flutter-segment/assets/65094540/fcc090ef-e2db-40f4-950c-c6cc8d989566">


