### PR TITLE
Add AGP 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,16 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 31
 
+    // For compatibility with AGP < 4.2
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.example.flutter_segment'
+    }
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+    
     lintOptions {
         disable 'InvalidPackage'
     }


### PR DESCRIPTION
Added new `namespace` property required by Android Gradle Plugin 8+ versions. With this change users can use AGP 8+ in their projects without issues like described in #75
Also added a check if this property is available as it appeared only since AGP 4.2 and some users might still use old version.

Closes #75 

P.S. I am not a big fan of supporting old AGPs and in Plus Plugins I decided to not do it, but since I don't know the policy for flutter_segment package about deprecation or old versions support went the way of compatibility here.