### PR TITLE
Update Appsflyer SDK iOS dependency

### DIFF
--- a/ios/flutter_segment.podspec
+++ b/ios/flutter_segment.podspec
@@ -19,7 +19,7 @@ Library to let Flutter apps use Segment.io
   s.dependency 'Flutter'
   s.dependency 'Analytics', '4.1.6'
   s.dependency 'Segment-Amplitude', '3.3.2'
-  s.dependency 'segment-appsflyer-ios', '6.10.1'
+  s.dependency 'segment-appsflyer-ios', '6.12.2'
   s.ios.deployment_target = '11.0'
 
   # Added because Segment-Amplitude dependencies on iOS cause this error:


### PR DESCRIPTION
Similar to this [update](https://github.com/la-haus/flutter-segment/pull/76) - bumping up the Appsflyer SDK iOS version to resolve dependency issue when using both flutter-segment and appsflyer_sdk (version 6.12.2) on flutter.